### PR TITLE
Fix file encoding issue on Windows by specifying UTF-8

### DIFF
--- a/sbommage
+++ b/sbommage
@@ -345,7 +345,7 @@ class Sbommage(App):
             return
 
         try:
-            with open(self.sbom_file, 'r') as f:
+            with open(self.sbom_file, 'r', encoding='utf-8') as f:
                 content = json.load(f)
             
             # Detect format


### PR DESCRIPTION
Fixes #7

Added explicit UTF-8 encoding to file open operation in load_sbom method to resolve character encoding errors on Windows systems. This ensures cross-platform compatibility when opening SBOM JSON files.